### PR TITLE
Generate query string signatures

### DIFF
--- a/lib/awsraw/s3/query_string_signer.rb
+++ b/lib/awsraw/s3/query_string_signer.rb
@@ -4,9 +4,15 @@ require 'cgi'
 module AWSRaw
   module S3
 
-    # Generates the signed query string for an authenticated GET request to S3
+    # Generates a signed query string to make an authenticated S3 GET request
     #
     # See http://docs.amazonwebservices.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationQueryStringAuth
+    #
+    # The Authorization header method is usually preferable, as implemented in
+    # AWSRaw::S3::Signer. However, you may have occasions where you need a
+    # simple "download URL", without having to tell your user-agent (browser,
+    # curl, wget, etc) about all the special AWS headers. The query string
+    # authentication method is useful in those cases.
     class QueryStringSigner < Signer
       def query_string(bucket, object, expires, headers = {})
         query_string_hash(bucket, object, expires, headers).map { |k,v|

--- a/lib/awsraw/s3/query_string_signer.rb
+++ b/lib/awsraw/s3/query_string_signer.rb
@@ -1,8 +1,5 @@
-require 'digest/sha1'
-require 'openssl'
-require 'uri'
+require 'awsraw/s3/signer'
 require 'cgi'
-require 'base64'
 
 module AWSRaw
   module S3
@@ -10,13 +7,7 @@ module AWSRaw
     # Generates the signed query string for an authenticated GET request to S3
     #
     # See http://docs.amazonwebservices.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationQueryStringAuth
-    class QueryStringSigner
-
-      def initialize(access_key_id, secret_access_key)
-        @access_key_id     = access_key_id
-        @secret_access_key = secret_access_key
-      end
-
+    class QueryStringSigner < Signer
       def query_string(bucket, object, expires, headers = {})
         query_string_hash(bucket, object, expires, headers).map { |k,v|
           "#{k}=#{v}"
@@ -25,10 +16,7 @@ module AWSRaw
 
       def query_string_hash(bucket, object, expires, headers = {})
         string_to_sign = string_to_sign(bucket, object, expires, headers)
-
-        digest    = OpenSSL::Digest::Digest.new("sha1")
-        sha       = OpenSSL::HMAC.digest(digest, @secret_access_key, string_to_sign)
-        signature = Base64.encode64(sha).strip
+        signature = encoded_signature(string_to_sign)
 
         {
           "AWSAccessKeyId" => @access_key_id,
@@ -49,16 +37,6 @@ module AWSRaw
       end
 
     private
-
-      def canonicalized_amz_headers(headers)
-        header_names = headers.keys.
-          select  {|name| name =~ /^x-amz-/i }.
-          sort_by {|name| name.downcase }
-
-        header_names.map do |name|
-          "#{name.downcase}:#{headers[name]}"
-        end
-      end
 
       # Assumes that bucket and object are already URI-encoded!
       def canonicalized_resource(bucket, object)

--- a/lib/awsraw/s3/query_string_signer.rb
+++ b/lib/awsraw/s3/query_string_signer.rb
@@ -14,10 +14,12 @@ module AWSRaw
     # curl, wget, etc) about all the special AWS headers. The query string
     # authentication method is useful in those cases.
     class QueryStringSigner < Signer
-      def query_string(url, expires)
-        query_string_hash(url, expires).map { |k,v|
-          "#{k}=#{v}"
-        }.join("&")
+      def sign_with_query_string(url, expires)
+        query_string_hash = query_string_hash(url, expires)
+
+        uri = URI.parse(url)
+        uri.query = query_string_hash.map { |k,v| "#{k}=#{v}" }.join("&")
+        uri.to_s
       end
 
       def query_string_hash(url, expires)

--- a/lib/awsraw/s3/query_string_signer.rb
+++ b/lib/awsraw/s3/query_string_signer.rb
@@ -14,14 +14,14 @@ module AWSRaw
     # curl, wget, etc) about all the special AWS headers. The query string
     # authentication method is useful in those cases.
     class QueryStringSigner < Signer
-      def query_string(bucket, object, expires, headers = {})
-        query_string_hash(bucket, object, expires, headers).map { |k,v|
+      def query_string(url, expires)
+        query_string_hash(url, expires).map { |k,v|
           "#{k}=#{v}"
         }.join("&")
       end
 
-      def query_string_hash(bucket, object, expires, headers = {})
-        string_to_sign = string_to_sign(bucket, object, expires, headers)
+      def query_string_hash(url, expires)
+        string_to_sign = string_to_sign(url, expires)
         signature = encoded_signature(string_to_sign)
 
         {
@@ -31,22 +31,18 @@ module AWSRaw
         }
       end
 
-      def string_to_sign(bucket, object, expires, headers = {})
+      def string_to_sign(url, expires)
         [
           "GET",
-          headers["Content-MD5"]  || "",
-          headers["Content-Type"] || "",
+          # Assume user-agent won't send Content-MD5 header
+          "",
+          # Assume user-agent won't send Content-Type header
+          "",
           expires.to_s,
-          canonicalized_amz_headers(headers),
-          canonicalized_resource(bucket, object)
+          # Assume user-agent won't send any amz headers
+          canonicalized_amz_headers({}),
+          canonicalized_resource(URI.parse(url))
         ].flatten.join("\n")
-      end
-
-    private
-
-      # Assumes that bucket and object are already URI-encoded!
-      def canonicalized_resource(bucket, object)
-        "/#{bucket}/#{object}"
       end
 
     end

--- a/lib/awsraw/s3/query_string_signer.rb
+++ b/lib/awsraw/s3/query_string_signer.rb
@@ -1,0 +1,71 @@
+require 'digest/sha1'
+require 'openssl'
+require 'uri'
+require 'cgi'
+require 'base64'
+
+module AWSRaw
+  module S3
+
+    # Generates the signed query string for an authenticated GET request to S3
+    #
+    # See http://docs.amazonwebservices.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationQueryStringAuth
+    class QueryStringSigner
+
+      def initialize(access_key_id, secret_access_key)
+        @access_key_id     = access_key_id
+        @secret_access_key = secret_access_key
+      end
+
+      def query_string(bucket, object, expires, headers = {})
+        query_string_hash(bucket, object, expires, headers).map { |k,v|
+          "#{k}=#{v}"
+        }.join("&")
+      end
+
+      def query_string_hash(bucket, object, expires, headers = {})
+        string_to_sign = string_to_sign(bucket, object, expires, headers)
+
+        digest    = OpenSSL::Digest::Digest.new("sha1")
+        sha       = OpenSSL::HMAC.digest(digest, @secret_access_key, string_to_sign)
+        signature = Base64.encode64(sha).strip
+
+        {
+          "AWSAccessKeyId" => @access_key_id,
+          "Expires"        => expires.to_s,
+          "Signature"      => CGI.escape(signature)
+        }
+      end
+
+      def string_to_sign(bucket, object, expires, headers = {})
+        [
+          "GET",
+          headers["Content-MD5"]  || "",
+          headers["Content-Type"] || "",
+          expires.to_s,
+          canonicalized_amz_headers(headers),
+          canonicalized_resource(bucket, object)
+        ].flatten.join("\n")
+      end
+
+    private
+
+      def canonicalized_amz_headers(headers)
+        header_names = headers.keys.
+          select  {|name| name =~ /^x-amz-/i }.
+          sort_by {|name| name.downcase }
+
+        header_names.map do |name|
+          "#{name.downcase}:#{headers[name]}"
+        end
+      end
+
+      # Assumes that bucket and object are already URI-encoded!
+      def canonicalized_resource(bucket, object)
+        "/#{bucket}/#{object}"
+      end
+
+    end
+
+  end
+end

--- a/lib/awsraw/s3/signer.rb
+++ b/lib/awsraw/s3/signer.rb
@@ -16,14 +16,20 @@ module AWSRaw
         @secret_access_key = secret_access_key
       end
 
-      def signature(request)
+      def authorization_header_value(request)
         string_to_sign = string_to_sign(request)
+        signature = encoded_signature(string_to_sign)
 
+        "AWS #{@access_key_id}:#{signature}"
+      end
+
+      # Backwards compatibility
+      alias_method :signature, :authorization_header_value
+
+      def encoded_signature(string_to_sign)
         digest    = OpenSSL::Digest::Digest.new("sha1")
         sha       = OpenSSL::HMAC.digest(digest, @secret_access_key, string_to_sign)
         signature = Base64.encode64(sha).strip
-
-        "AWS #{@access_key_id}:#{signature}"
       end
 
       def string_to_sign(request)

--- a/spec/s3/query_string_signer_spec.rb
+++ b/spec/s3/query_string_signer_spec.rb
@@ -8,15 +8,13 @@ describe AWSRaw::S3::QueryStringSigner do
 
   context "examples from Amazon docs" do
     it "signs a get request correctly" do
-      bucket = "johnsmith"
-      object = "photos/puppy.jpg"
+      url = "http://s3.amazonaws.com/johnsmith/photos/puppy.jpg"
       expiry = 1175139620
 
-      p subject.string_to_sign(bucket, object, expiry)
-      subject.string_to_sign(bucket, object, expiry).should ==
+      subject.string_to_sign(url, expiry).should ==
         "GET\n\n\n#{expiry}\n/johnsmith/photos/puppy.jpg"
 
-      subject.query_string_hash(bucket, object, expiry).should == {
+      subject.query_string_hash(url, expiry).should == {
         "AWSAccessKeyId" => access_key_id,
         "Expires"        => expiry.to_s,
         "Signature"      => "NpgCjnDzrM%2BWFzoENXmpNDUsSn8%3D"

--- a/spec/s3/query_string_signer_spec.rb
+++ b/spec/s3/query_string_signer_spec.rb
@@ -19,6 +19,9 @@ describe AWSRaw::S3::QueryStringSigner do
         "Expires"        => expiry.to_s,
         "Signature"      => "NpgCjnDzrM%2BWFzoENXmpNDUsSn8%3D"
       }
+
+      subject.sign_with_query_string(url, expiry).to_s.should ==
+        "http://s3.amazonaws.com/johnsmith/photos/puppy.jpg?AWSAccessKeyId=#{access_key_id}&Expires=#{expiry}&Signature=NpgCjnDzrM%2BWFzoENXmpNDUsSn8%3D"
     end
 
   end

--- a/spec/s3/query_string_signer_spec.rb
+++ b/spec/s3/query_string_signer_spec.rb
@@ -1,0 +1,28 @@
+require 'awsraw/s3/query_string_signer'
+
+describe AWSRaw::S3::QueryStringSigner do
+  let(:access_key_id)     { "AKIAIOSFODNN7EXAMPLE" }
+  let(:secret_access_key) { "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" }
+
+  subject { AWSRaw::S3::QueryStringSigner.new(access_key_id, secret_access_key) }
+
+  context "examples from Amazon docs" do
+    it "signs a get request correctly" do
+      bucket = "johnsmith"
+      object = "photos/puppy.jpg"
+      expiry = 1175139620
+
+      p subject.string_to_sign(bucket, object, expiry)
+      subject.string_to_sign(bucket, object, expiry).should ==
+        "GET\n\n\n#{expiry}\n/johnsmith/photos/puppy.jpg"
+
+      subject.query_string_hash(bucket, object, expiry).should == {
+        "AWSAccessKeyId" => access_key_id,
+        "Expires"        => expiry.to_s,
+        "Signature"      => "NpgCjnDzrM%2BWFzoENXmpNDUsSn8%3D"
+      }
+    end
+
+  end
+end
+

--- a/spec/s3/signer_spec.rb
+++ b/spec/s3/signer_spec.rb
@@ -1,8 +1,8 @@
 require 'awsraw/s3/signer'
 
 describe AWSRaw::S3::Signer do
-  let(:access_key_id)     { "0PN5J17HBGZHT7JJ3X82" }
-  let(:secret_access_key) { "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o" }
+  let(:access_key_id)     { "AKIAIOSFODNN7EXAMPLE" }
+  let(:secret_access_key) { "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" }
 
   subject { AWSRaw::S3::Signer.new(access_key_id, secret_access_key) }
 
@@ -17,7 +17,7 @@ describe AWSRaw::S3::Signer do
       subject.string_to_sign(request).should ==
         "GET\n\n\nTue, 27 Mar 2007 19:36:42 +0000\n/johnsmith/photos/puppy.jpg"
 
-      subject.signature(request).should == "AWS #{access_key_id}:xXjDGYUmKxnwqr5KXNPGldn5LbA="
+      subject.signature(request).should == "AWS #{access_key_id}:bWq2s1WEIj+Ydj0vQ697zp+IXMU="
     end
 
     it "signs an upload correctly" do
@@ -42,7 +42,7 @@ describe AWSRaw::S3::Signer do
       subject.string_to_sign(request).should ==
         "PUT\n4gJE4saaMU4BqNR0kLY+lw==\napplication/x-download\nTue, 27 Mar 2007 21:06:08 +0000\nx-amz-acl:public-read\nx-amz-meta-checksumalgorithm:crc32\nx-amz-meta-filechecksum:0x02661779\nx-amz-meta-reviewedby:joe@johnsmith.net,jane@johnsmith.net\n/static.johnsmith.net/db-backup.dat.gz"
 
-      subject.signature(request).should == "AWS #{access_key_id}:C0FlOtU8Ylb9KDTpZqYkZPX91iI="
+      subject.signature(request).should == "AWS #{access_key_id}:ilyl83RwaSoYIEdixDQcA4OnAnc="
     end
 
   end


### PR DESCRIPTION
Most of the time, the original `S3::Signer` class's method of generating an `Authorization` header value is what you want. However, there are times when you want to simply pass a URL around, assuming that the user-agent which will make the request won't want to use any special HTTP headers. For these cases, you can use a query string signature.
