### PR TITLE
Support non standard regions.

### DIFF
--- a/lib/awsraw/s3/request.rb
+++ b/lib/awsraw/s3/request.rb
@@ -5,6 +5,8 @@ require 'uri'
 module AWSRaw
   module S3
 
+    US_STANDARD = "us-east-1"
+
     # Note that we use path style (rather than virtual hosted style) requests.
     # This is because virtual hosted requests only support lower case bucket
     # names.
@@ -35,7 +37,7 @@ module AWSRaw
       attr_reader :content
 
       def host
-        if @region
+        if @region && @region != US_STANDARD
           "s3-#{@region}.amazonaws.com"
         else
           "s3.amazonaws.com"

--- a/lib/awsraw/s3/request.rb
+++ b/lib/awsraw/s3/request.rb
@@ -14,6 +14,7 @@ module AWSRaw
       def initialize(params, signer)
         @method  = params[:method]
         @bucket  = params[:bucket]
+        @region  = params[:region]
         @key     = params[:key]
         @query   = params[:query]
         @headers = params[:headers] || {}
@@ -34,12 +35,17 @@ module AWSRaw
       attr_reader :content
 
       def host
-        "s3.amazonaws.com"
+        if @region
+          "s3-#{@region}.amazonaws.com"
+        else
+          "s3.amazonaws.com"
+        end
       end
 
       def path
-        @path ||= URI.escape("/#{bucket}#{key}")
+        @path ||= URI.escape("/" + [bucket, key].compact.join("/"))
       end
+
 
       def uri
         @uri ||= URI::HTTP.build(

--- a/spec/s3/client_spec.rb
+++ b/spec/s3/client_spec.rb
@@ -11,7 +11,7 @@ describe AWSRaw::S3::Client do
 
       expect {
         subject.request!(:method => "PUT")
-      }.should_not raise_error
+      }.to_not raise_error
     end
 
     it "raises an error if the response indicates failure" do
@@ -20,7 +20,7 @@ describe AWSRaw::S3::Client do
 
       expect {
         subject.request!(:method => "PUT")
-      }.should raise_error("Uh oh! Failure from S3.")
+      }.to raise_error("Uh oh! Failure from S3.")
     end
   end
 

--- a/spec/s3/request_spec.rb
+++ b/spec/s3/request_spec.rb
@@ -1,0 +1,52 @@
+require 'awsraw/s3/client'
+
+describe AWSRaw::S3::Request do
+
+  let(:access_key)        { 'key' }
+  let(:secret_access_key) { 'secret' }
+  let(:bucket)            { 'envato.com' }
+  let(:key)               { 'index.html' }
+
+  let(:signer)            { AWSRaw::S3::Signer.new(access_key, secret_access_key) }
+  let(:params)            { Hash.new }
+
+  subject { AWSRaw::S3::Request.new(params, signer) }
+
+  before do
+    params[:bucket] = bucket
+  end
+
+  describe "#host" do
+
+    it "defaults to the standard host" do
+      subject.host.should == "s3.amazonaws.com"
+    end
+
+    it "uses the region specific host when a region is supplied" do
+      params[:region] = 'ap-southeast-2'
+
+      subject.host.should == "s3-ap-southeast-2.amazonaws.com"
+    end
+  end
+
+  describe "#path" do
+
+    it "includes the bucket name" do
+      subject.path.should == "/#{bucket}"
+    end
+
+    context "when a key has been supplied" do
+
+      before do
+        params[:key]    = key
+      end
+
+      it "includes the bucket name and key" do
+        subject.path.should == "/#{bucket}/#{key}"
+      end
+    end
+
+  end
+
+end
+

--- a/spec/s3/request_spec.rb
+++ b/spec/s3/request_spec.rb
@@ -22,7 +22,13 @@ describe AWSRaw::S3::Request do
       s3_request.host.should == "s3.amazonaws.com"
     end
 
-    it "uses the region specific host when a region is supplied" do
+    it "ignores the region if it is the standard region" do
+      params[:region] = 'us-east-1'
+
+      s3_request.host.should == "s3.amazonaws.com"
+    end
+
+    it "uses the region specific host when a non standard region is supplied" do
       params[:region] = 'ap-southeast-2'
 
       s3_request.host.should == "s3-ap-southeast-2.amazonaws.com"

--- a/spec/s3/request_spec.rb
+++ b/spec/s3/request_spec.rb
@@ -10,7 +10,7 @@ describe AWSRaw::S3::Request do
   let(:signer)            { AWSRaw::S3::Signer.new(access_key, secret_access_key) }
   let(:params)            { Hash.new }
 
-  subject { AWSRaw::S3::Request.new(params, signer) }
+  subject(:s3_request) { AWSRaw::S3::Request.new(params, signer) }
 
   before do
     params[:bucket] = bucket
@@ -19,34 +19,33 @@ describe AWSRaw::S3::Request do
   describe "#host" do
 
     it "defaults to the standard host" do
-      subject.host.should == "s3.amazonaws.com"
+      s3_request.host.should == "s3.amazonaws.com"
     end
 
     it "uses the region specific host when a region is supplied" do
       params[:region] = 'ap-southeast-2'
 
-      subject.host.should == "s3-ap-southeast-2.amazonaws.com"
+      s3_request.host.should == "s3-ap-southeast-2.amazonaws.com"
     end
   end
 
   describe "#path" do
 
     it "includes the bucket name" do
-      subject.path.should == "/#{bucket}"
+      s3_request.path.should == "/#{bucket}"
     end
 
     context "when a key has been supplied" do
 
       before do
-        params[:key]    = key
+        params[:key] = key
       end
 
       it "includes the bucket name and key" do
-        subject.path.should == "/#{bucket}/#{key}"
+        s3_request.path.should == "/#{bucket}/#{key}"
       end
     end
 
   end
 
 end
-


### PR DESCRIPTION
Allow the region to be specified when making a request to a bucket stored outside us-east-1.
