### PR TITLE
Add support to pass File objects as content

### DIFF
--- a/lib/awsraw/s3/client.rb
+++ b/lib/awsraw/s3/client.rb
@@ -2,6 +2,7 @@ require 'net/http'
 require 'awsraw/s3/request'
 require 'awsraw/s3/response'
 require 'awsraw/s3/signer'
+require 'awsraw/s3/md5_digester'
 
 module AWSRaw
   module S3
@@ -43,7 +44,12 @@ module AWSRaw
           request.headers.each do |name, value|
             http_request[name] = value
           end
-          http_request.body = request.content
+          if request.content.is_a?(File)
+            http_request.body_stream = request.content
+            http_request['Content-Length'] = request.content.size.to_s
+          else
+            http_request.body = request.content
+          end
         end
       end
 

--- a/lib/awsraw/s3/client.rb
+++ b/lib/awsraw/s3/client.rb
@@ -7,6 +7,8 @@ require 'awsraw/s3/md5_digester'
 module AWSRaw
   module S3
 
+    class ConnectionError < StandardError; end
+
     # A client for the AWS S3 rest API.
     #
     # http://docs.amazonwebservices.com/AmazonS3/latest/API/APIRest.html
@@ -31,7 +33,7 @@ module AWSRaw
 
       def request!(params = {})
         response = request(params)
-        raise "Uh oh! Failure from S3." if response.failure?
+        raise ConnectionError, response.inspect if response.failure?
       end
 
     private

--- a/lib/awsraw/s3/http_request_builder.rb
+++ b/lib/awsraw/s3/http_request_builder.rb
@@ -1,0 +1,49 @@
+require 'net/http'
+module AWSRaw
+  module S3
+    class HTTPRequestBuilder
+      attr_reader :s3_request
+
+      def initialize(s3_request)
+        @s3_request = s3_request
+      end
+
+      def build
+        klass = http_request_class(s3_request)
+        path  = s3_request.uri.request_uri
+
+        klass.new(path).tap do |http_request|
+          s3_request.headers.each do |name, value|
+            http_request[name] = value
+          end
+          set_content_on_request(http_request, s3_request.content)
+        end
+      end
+
+      private
+
+      def http_request_class(s3_request)
+        case s3_request.method
+          when "GET"
+            Net::HTTP::Get
+          when "HEAD"
+            Net::HTTP::Head
+          when "PUT"
+            Net::HTTP::Put
+          else
+            raise "Invalid HTTP method!"
+        end
+      end
+
+      def set_content_on_request(http_request, content)
+        if content.is_a?(File)
+          http_request.body_stream = content
+          http_request['Content-Length'] = content.size.to_s
+        else
+          http_request.body = content
+        end
+      end
+
+    end
+  end
+end

--- a/lib/awsraw/s3/md5_digester.rb
+++ b/lib/awsraw/s3/md5_digester.rb
@@ -1,0 +1,19 @@
+module AWSRaw
+  module S3
+    class MD5Digester
+      def initialize(string_or_file)
+        @string_or_file = string_or_file
+      end
+
+      def digest
+        if @string_or_file.is_a?(File)
+          Digest::MD5.file(@string_or_file.path).digest
+        elsif @string_or_file.is_a?(String)
+          Digest::MD5.digest(@string_or_file)
+        else
+          raise "Unable to digest #{@string_or_file.class}"
+        end
+      end
+    end
+  end
+end

--- a/lib/awsraw/s3/request.rb
+++ b/lib/awsraw/s3/request.rb
@@ -50,7 +50,7 @@ module AWSRaw
       end
 
       def content_md5
-        @content_md5 ||= Base64.encode64(Digest::MD5.digest(content)).strip
+        @content_md5 ||= Base64.encode64(MD5Digester.new(content).digest).strip
       end
     end
 

--- a/spec/s3/client_spec.rb
+++ b/spec/s3/client_spec.rb
@@ -1,3 +1,4 @@
+
 require 'awsraw/s3/client'
 
 describe AWSRaw::S3::Client do
@@ -11,7 +12,7 @@ describe AWSRaw::S3::Client do
 
       expect {
         subject.request!(:method => "PUT")
-      }.should_not raise_error
+      }.to_not raise_error
     end
 
     it "raises an error if the response indicates failure" do
@@ -20,7 +21,7 @@ describe AWSRaw::S3::Client do
 
       expect {
         subject.request!(:method => "PUT")
-      }.should raise_error("Uh oh! Failure from S3.")
+      }.to raise_error(::AWSRaw::S3::ConnectionError)
     end
   end
 

--- a/spec/s3/client_spec.rb
+++ b/spec/s3/client_spec.rb
@@ -1,11 +1,10 @@
-
 require 'awsraw/s3/client'
 
 describe AWSRaw::S3::Client do
 
   subject { AWSRaw::S3::Client.new("dummy_access_key_id", "dummy_secret_access_key") }
 
-  context "#request!" do
+  describe "#request!" do
     it "returns if the response indicates success" do
       response = stub(:failure? => false)
       subject.stub(:request => response)
@@ -24,6 +23,5 @@ describe AWSRaw::S3::Client do
       }.to raise_error(::AWSRaw::S3::ConnectionError)
     end
   end
-
 end
 

--- a/spec/s3/http_request_builder_spec.rb
+++ b/spec/s3/http_request_builder_spec.rb
@@ -1,0 +1,45 @@
+require 'awsraw/s3/http_request_builder'
+
+describe AWSRaw::S3::HTTPRequestBuilder do
+  subject do
+    AWSRaw::S3::HTTPRequestBuilder.new(s3_request)
+  end
+
+  let(:content) { "hello world" }
+  let(:s3_request) do
+    stub(
+      :uri => URI.parse("http://foo.com/foo"),
+      :headers => {"Content-Type" => "application/not-real"},
+      :content => content,
+      :method => "PUT"
+    )
+  end
+
+  context "content is a string" do
+    let(:content) { "hello world" }
+    it "sets the body on the http request to content" do
+      subject.build.body.should == content
+    end
+  end
+
+  context "content is a file object" do
+    let(:content) { File.open(__FILE__, "rb") }
+    it "sets the body on the http request to content" do
+      http_request = subject.build
+      http_request.body_stream.should == content
+      http_request['Content-Length'].should == File.size(__FILE__).to_s
+    end
+  end
+
+  it "sets the path on the request" do
+    subject.build.path.should == "/foo"
+  end
+
+  it "sets the headers" do
+    subject.build["Content-Type"].should == "application/not-real"
+  end
+
+  it "returns the appropriate request class" do
+    subject.build.class.should == Net::HTTP::Put
+  end
+end

--- a/spec/s3/md5_digester_spec.rb
+++ b/spec/s3/md5_digester_spec.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+require 'awsraw/s3/md5_digester'
+
+describe AWSRaw::S3::MD5Digester do
+
+  describe "#digest" do
+    it "returns the md5 digest of the string" do
+      AWSRaw::S3::MD5Digester.new("hello").digest.should == Digest::MD5.digest("hello")
+    end
+
+    it "returns the md5 digest of a file" do
+      file = File.open(__FILE__, "rb")
+      AWSRaw::S3::MD5Digester.new(file).digest.should == Digest::MD5.file(__FILE__).digest
+    end
+
+    it "raises an error on unknown input" do
+      expect { AWSRaw::S3::MD5Digester.new(3).digest }.to raise_error("Unable to digest Fixnum")
+    end
+  end
+end
+


### PR DESCRIPTION
This allows you to pass `File` objects as content to upload files to S3 rather than have to read it all into memory.
