### PR TITLE
Support query-string signing with custom headers

### DIFF
--- a/lib/awsraw/s3/query_string_signer.rb
+++ b/lib/awsraw/s3/query_string_signer.rb
@@ -33,16 +33,13 @@ module AWSRaw
         }
       end
 
-      def string_to_sign(url, expires)
+      def string_to_sign(url, expires, headers = {})
         [
           "GET",
-          # Assume user-agent won't send Content-MD5 header
-          "",
-          # Assume user-agent won't send Content-Type header
-          "",
+          headers["Content-MD5"],
+          headers["Content-Type"],
           expires.to_s,
-          # Assume user-agent won't send any amz headers
-          canonicalized_amz_headers({}),
+          canonicalized_amz_headers(headers),
           canonicalized_resource(URI.parse(url))
         ].flatten.join("\n")
       end

--- a/lib/awsraw/s3/query_string_signer.rb
+++ b/lib/awsraw/s3/query_string_signer.rb
@@ -14,16 +14,16 @@ module AWSRaw
     # curl, wget, etc) about all the special AWS headers. The query string
     # authentication method is useful in those cases.
     class QueryStringSigner < Signer
-      def sign_with_query_string(url, expires)
-        query_string_hash = query_string_hash(url, expires)
+      def sign_with_query_string(url, expires, headers = {})
+        query_string_hash = query_string_hash(url, expires, headers)
 
         uri = URI.parse(url)
         uri.query = query_string_hash.map { |k,v| "#{k}=#{v}" }.join("&")
         uri.to_s
       end
 
-      def query_string_hash(url, expires)
-        string_to_sign = string_to_sign(url, expires)
+      def query_string_hash(url, expires, headers = {})
+        string_to_sign = string_to_sign(url, expires, headers)
         signature = encoded_signature(string_to_sign)
 
         {
@@ -33,7 +33,7 @@ module AWSRaw
         }
       end
 
-      def string_to_sign(url, expires, headers = {})
+      def string_to_sign(url, expires, headers)
         [
           "GET",
           headers["Content-MD5"],

--- a/spec/s3/query_string_signer_spec.rb
+++ b/spec/s3/query_string_signer_spec.rb
@@ -10,8 +10,9 @@ describe AWSRaw::S3::QueryStringSigner do
     it "signs a get request correctly" do
       url = "http://s3.amazonaws.com/johnsmith/photos/puppy.jpg"
       expiry = 1175139620
+      headers = {}
 
-      subject.string_to_sign(url, expiry).should ==
+      subject.string_to_sign(url, expiry, {}).should ==
         "GET\n\n\n#{expiry}\n/johnsmith/photos/puppy.jpg"
 
       subject.query_string_hash(url, expiry).should == {
@@ -27,8 +28,9 @@ describe AWSRaw::S3::QueryStringSigner do
     it "signs a get request to a non-us-east bucket" do
       url = "http://johnsmith.s3.amazonaws.com/photos/puppy.jpg"
       expiry = 1175139620
+      headers = {}
 
-      subject.string_to_sign(url, expiry).should ==
+      subject.string_to_sign(url, expiry, headers).should ==
         "GET\n\n\n#{expiry}\n/johnsmith/photos/puppy.jpg"
 
       subject.query_string_hash(url, expiry).should == {

--- a/spec/s3/query_string_signer_spec.rb
+++ b/spec/s3/query_string_signer_spec.rb
@@ -41,5 +41,25 @@ describe AWSRaw::S3::QueryStringSigner do
         "http://johnsmith.s3.amazonaws.com/photos/puppy.jpg?AWSAccessKeyId=#{access_key_id}&Expires=#{expiry}&Signature=NpgCjnDzrM%2BWFzoENXmpNDUsSn8%3D"
     end
   end
+
+  context "custom headers" do
+    let(:url) { "http://s3.amazonaws.com/johnsmith/" }
+    let(:expiry) { 1175139620 }
+
+    it "changes the signature based on the Content-MD5 header" do
+      subject.string_to_sign(url, expiry, "Content-MD5" => "deadbeef").should ==
+        "GET\ndeadbeef\n\n#{expiry}\n/johnsmith/"
+    end
+
+    it "changes the signature based on the Content-Type header" do
+      subject.string_to_sign(url, expiry, "Content-Type" => "image/png").should ==
+        "GET\n\nimage/png\n#{expiry}\n/johnsmith/"
+    end
+
+    it "changes the signature based on x-amz-* headers" do
+      subject.string_to_sign(url, expiry, "x-amz-acl" => "public-read").should ==
+        "GET\n\n\n#{expiry}\nx-amz-acl:public-read\n/johnsmith/"
+    end
+  end
 end
 


### PR DESCRIPTION
For simple presigned POSTs we could reasonably assume that a browser
wasn't going to send any interesting headers. In many other cases, this
assumption doesn't hold. For example - browser-based uploads via
PutObject where you want to set the Content-MD5 header, or a
Content-Type.

This PR allows you to pass a hash of headers to any of the methods on
`QueryStringSigner`, which will be included in the signing algorithm as
documented on the AWS site.
